### PR TITLE
Rearrange: throw error if argument contains nullptr

### DIFF
--- a/libsse/include/sse/slicer.hpp
+++ b/libsse/include/sse/slicer.hpp
@@ -83,14 +83,15 @@ LIBSSE_EXPORT void setup_logger(spdlog::level::level_enum loglevel = spdlog::lev
  *
  *
  * @throws std::invalid_argument
- * - bed dimensions <= 0
- * - too many objects
- * - object footprint is larger than bed dimensions
- * - object has zero footprint
+ * - objects contains a nullptr
+ * - bed_width or bed_length <= 0
+ * - objects.size() > SSE_MAXIMUM_NUM_OBJECTS
+ * - any object footprint is larger than bed dimensions
+ * - any object has zero footprint
  *
  * @throws std::runtime_error
  * - aggregate footprint of rearranged objects is larger than the bed
- * - can't determine correct growth direction of bin
+ * - cannot determine correct growth direction of bin
  */
 LIBSSE_EXPORT void rearrange_objects(std::vector<std::unique_ptr<Object> > &objects, const double bed_width, const double bed_length);
 

--- a/libsse/src/Rearrange.cpp
+++ b/libsse/src/Rearrange.cpp
@@ -222,7 +222,7 @@ void sse::rearrange_objects(std::vector<std::unique_ptr<sse::Object>> &objects,
 
   // negative bed dimensions are invalid
   if (bed_width <= 0 || bed_length <= 0) {
-    spdlog::error("Rearrange: bed dimensions cannot be < 0");
+    spdlog::error("Rearrange: bed dimensions cannot be <= 0");
     throw std::invalid_argument("Rearrange: invalid bed dimensions");
   }
 
@@ -239,6 +239,12 @@ void sse::rearrange_objects(std::vector<std::unique_ptr<sse::Object>> &objects,
 
   // check for invalid objects
   for (const auto &o : objects) {
+
+    if(o == nullptr) {
+      spdlog::error("Rearrange: object list contains nullptr");
+      throw std::invalid_argument("Rearrange: object list contains nullptr");
+    }
+
 #if OCC_VERSION_HEX >= 0x070400
     if (o->get_bound_box().IsOpen()) {
 #else
@@ -248,17 +254,17 @@ void sse::rearrange_objects(std::vector<std::unique_ptr<sse::Object>> &objects,
         o->get_bound_box().IsOpenZmin() || o->get_bound_box().IsOpenZmax()) {
     // clang-format on
 #endif
-      spdlog::error("Rearrange: Error: object with infinite dimension");
+      spdlog::error("Rearrange: object with infinite dimension");
       throw std::invalid_argument("Rearrange: object has infinite volume");
     }
 
     if (o->get_bound_box().IsVoid()) {
-      spdlog::error("Rearrange: Error: empty object");
+      spdlog::error("Rearrange: empty object");
       throw std::invalid_argument("Rearrange: object is empty");
     }
 
     if (o->width() > bed_width || o->length() > bed_length) {
-      spdlog::error("Rearrange: Error: object ({:.3f}x{:.3f}) too large for "
+      spdlog::error("Rearrange: object ({:.3f}x{:.3f}) too large for "
                     "bed ({:.3f}x{:.3f})",
                     o->width(), o->length(), bed_width, bed_length);
       throw std::invalid_argument("Rearrange: object too large for bed");
@@ -314,7 +320,7 @@ void sse::rearrange_objects(std::vector<std::unique_ptr<sse::Object>> &objects,
       } else {
         // the only way to reach this codepath is if the object is changed underneath us
         spdlog::error(
-            "Rearrange Error: Can't determine correct growth direction of bin");
+            "Rearrange Can't determine correct growth direction of bin");
         throw std::runtime_error(
             "Rearrange: Can't determine correct growth direction of bin");
       }

--- a/tests/test_rearrange.cpp
+++ b/tests/test_rearrange.cpp
@@ -77,6 +77,12 @@ TEST_SUITE("Rearrange Objects") {
       CHECK_THROWS_AS(sse::rearrange_objects(objects, 11, 11), std::runtime_error);
     }
 
+    SUBCASE("Objects vector contains nullptr") {
+      objects.push_back(nullptr);
+
+      CHECK_THROWS_AS(sse::rearrange_objects(objects, 100, 100), std::invalid_argument);
+    }
+
   }
 
   TEST_CASE("Valid Tests") {


### PR DESCRIPTION
Add corresponding unit test
cleanup log messages